### PR TITLE
Update org.gnome.Games

### DIFF
--- a/org.gnome.Games.json
+++ b/org.gnome.Games.json
@@ -51,7 +51,7 @@
         "libretro-cores/libretro-pcsx_rearmed.json",
         "libretro-cores/libretro-prosystem.json",
         "libretro-cores/libretro-stella2014.json",
-        "shared-modules/lua5.3/lua-5.3.2.json",
+        "shared-modules/lua5.3/lua-5.3.5.json",
         {
             "name" : "tracker",
             "buildsystem" : "meson",
@@ -88,8 +88,8 @@
                 {
                     "type" : "git",
                     "url" : "https://gitlab.gnome.org/GNOME/grilo.git",
-                    "tag" : "grilo-0.3.9",
-                    "commit" : "9a5951cfbe8776c609c0563e449f4f17518ae072"
+                    "tag" : "grilo-0.3.10",
+                    "commit" : "ec6a37b7474010e60a8949b8e7a38f828e3b005e"
                 }
             ],
             "cleanup" : [
@@ -130,8 +130,8 @@
                 {
                     "type" : "git",
                     "url" : "https://gitlab.gnome.org/GNOME/grilo-plugins.git",
-                    "tag" : "grilo-plugins-0.3.9",
-                    "commit" : "0f3bce0fcf8b157ef0e6bdcc02c0fbb92f5a26b9"
+                    "tag" : "grilo-plugins-0.3.10",
+                    "commit" : "a6330af7d607a6a20364ec2924ad152d16c50cf2"
                 }
             ],
             "cleanup" : [
@@ -204,8 +204,7 @@
                 {
                     "type" : "git",
                     "url" : "https://gitlab.gnome.org/GNOME/gnome-games.git",
-                    "tag" : "3.34.0",
-                    "commit" : "d6e511a9b9d451ce6755fff19390ae9880585896"
+                    "commit" : "fc9a963cce0bd9d04e93f48d04cefe1df1990c94"
                 }
             ]
         }


### PR DESCRIPTION
- Update shared-modules.
- Bump lua5.3 to 5.3.5.
- Bump grilo to 0.3.11.
- Bump grilo-plugins to 0.3.11.
- Bump gnome-games to a more recent commit.