### PR TITLE
flathub.json: Remove i386 arch

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,3 @@
 {
-  "only-arches": [ "i386", "x86_64", "aarch64" ]
+  "only-arches": [ "x86_64", "aarch64" ]
 }


### PR DESCRIPTION
It's not supported anymore.